### PR TITLE
feat: Implemented script for 8-way movement

### DIFF
--- a/src/scenes/player/player.gd
+++ b/src/scenes/player/player.gd
@@ -12,7 +12,21 @@ func _physics_process(delta: float) -> void:
 	# Move player
 	move_and_slide()
 
-	# Clamp position
-	var screen_rect = get_viewport_rect()
-	position.x = clamp(position.x, 0.0, screen_rect.size.x)
-	position.y = clamp(position.y, 0.0, screen_rect.size.y)
+    # Clamp position accounting for collision shape bounds
+    var screen_rect = get_viewport_rect()
+    var collision_shape = $CollisionShape2D
+    assert(collision_shape != null, "Player requires a CollisionShape2D child node")
+    assert(collision_shape.shape != null, "CollisionShape2D requires a shape resource")
+    
+    var half_size := Vector2.ZERO
+    # Handle different shape types
+    if collision_shape.shape is RectangleShape2D:
+        half_size = collision_shape.shape.size / 2.0
+    elif collision_shape.shape is CircleShape2D:
+        var radius = collision_shape.shape.radius
+        half_size = Vector2(radius, radius)
+    elif collision_shape.shape is CapsuleShape2D:
+        half_size = Vector2(collision_shape.shape.radius, collision_shape.shape.height / 2.0)
+    
+    position.x = clamp(position.x, half_size.x, screen_rect.size.x - half_size.x)
+    position.y = clamp(position.y, half_size.y, screen_rect.size.y - half_size.y)


### PR DESCRIPTION
Fixes #6 

**Summary**
Created `player.gd` script attached to `player.tscn`.
- 8-way movement implemented using `Input.get_vector`.
- Velocity based movement implemented using `move_and_slide`.
- Clamped player position within the viewport bounds.

---

**Testing**  
- Tested movement in all 8 directions using WASD and Arrow keys.
- Confirmed player cannot move outside the viewport.  
