### PR TITLE
feat: Add triangle placeholder sprite for player ship

### DIFF
--- a/src/assets/icon.svg.import
+++ b/src/assets/icon.svg.import
@@ -3,15 +3,15 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cxwft1tdgcb33"
-path="res://.godot/imported/icon.svg-218a8f2b3041327d8a5756f3a245f83b.ctex"
+path="res://.godot/imported/icon.svg-56083ea2a1f1a4f1e49773bdc6d7826c.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://icon.svg"
-dest_files=["res://.godot/imported/icon.svg-218a8f2b3041327d8a5756f3a245f83b.ctex"]
+source_file="res://assets/icon.svg"
+dest_files=["res://.godot/imported/icon.svg-56083ea2a1f1a4f1e49773bdc6d7826c.ctex"]
 
 [params]
 

--- a/src/project.godot
+++ b/src/project.godot
@@ -15,14 +15,6 @@ run/main_scene="res://scenes/main.tscn"
 config/features=PackedStringArray("4.5", "Forward Plus")
 config/icon="res://assets/icon.svg"
 
-[autoload]
-
-GDAIMCPRuntime="*res://addons/gdai-mcp-plugin-godot/gdai_mcp_runtime.gd"
-
-[editor_plugins]
-
-enabled=PackedStringArray("res://addons/gdai-mcp-plugin-godot/plugin.cfg")
-
 [input]
 
 move_up={

--- a/src/scenes/player/player.tscn
+++ b/src/scenes/player/player.tscn
@@ -7,3 +7,7 @@ radius = 16.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_x7p2l")
+
+[node name="Polygon2D" type="Polygon2D" parent="."]
+color = Color(0.3, 0.7, 1, 1)
+polygon = PackedVector2Array(0, -20, -12, 10, 12, 10)


### PR DESCRIPTION
- Replaces Player default Godot icon with upward-pointing triangle Polygon2D
- Light blue color for visibility

This also cleans up some project configuration errors 
- Updates the Godot icon asset import path and generated asset hash/UID
- Removes erroneous MCP plugin references from project.godot 


Resolves #5