### PR TITLE
feat: Add GitHub Actions workflow for automatic deployment to itch.io

### DIFF
--- a/.github/workflows/deploy-itchio.yml
+++ b/.github/workflows/deploy-itchio.yml
@@ -140,6 +140,11 @@ jobs:
         env:
           BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
         run: |
-          butler push build/web ${{ env.ITCH_USER }}/${{ env.ITCH_GAME }}:html5 --userversion ${{ github.ref_name }}
-          butler push build/windows ${{ env.ITCH_USER }}/${{ env.ITCH_GAME }}:windows --userversion ${{ github.ref_name }}
-          butler push build/linux ${{ env.ITCH_USER }}/${{ env.ITCH_GAME }}:linux --userversion ${{ github.ref_name }}
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            USERVERSION="$(date -u +'%Y%m%d%H%M%S')-manual"
+          else
+            USERVERSION="${{ github.ref_name }}"
+          fi
+          butler push build/web ${{ env.ITCH_USER }}/${{ env.ITCH_GAME }}:html5 --userversion "$USERVERSION"
+          butler push build/windows ${{ env.ITCH_USER }}/${{ env.ITCH_GAME }}:windows --userversion "$USERVERSION"
+          butler push build/linux ${{ env.ITCH_USER }}/${{ env.ITCH_GAME }}:linux --userversion "$USERVERSION"

--- a/.github/workflows/deploy-itchio.yml
+++ b/.github/workflows/deploy-itchio.yml
@@ -1,0 +1,145 @@
+name: Deploy to itch.io
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  GODOT_VERSION: "4.5"
+  PROJECT_PATH: src
+  EXPORT_NAME: ShooterCarnival
+  ITCH_USER: houzenkai
+  ITCH_GAME: shooter-carnival
+
+jobs:
+  export-web:
+    name: Web Export
+    runs-on: ubuntu-latest
+    container:
+      image: barichello/godot-ci:4.5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Setup Export Templates
+        run: |
+          mkdir -v -p ~/.local/share/godot/export_templates/
+          mkdir -v -p ~/.config/
+          mv /root/.config/godot ~/.config/godot
+          mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
+
+      - name: Build Web Export
+        run: |
+          mkdir -v -p build/web
+          EXPORT_DIR="$(readlink -f build)"
+          cd $PROJECT_PATH
+          godot --headless --verbose --export-release "Web" "$EXPORT_DIR/web/index.html"
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-build
+          path: build/web
+          retention-days: 1
+
+  export-windows:
+    name: Windows Export
+    runs-on: ubuntu-latest
+    container:
+      image: barichello/godot-ci:4.5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Setup Export Templates
+        run: |
+          mkdir -v -p ~/.local/share/godot/export_templates/
+          mkdir -v -p ~/.config/
+          mv /root/.config/godot ~/.config/godot
+          mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
+
+      - name: Build Windows Export
+        run: |
+          mkdir -v -p build/windows
+          EXPORT_DIR="$(readlink -f build)"
+          cd $PROJECT_PATH
+          godot --headless --verbose --export-release "Windows Desktop" "$EXPORT_DIR/windows/$EXPORT_NAME.exe"
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-build
+          path: build/windows
+          retention-days: 1
+
+  export-linux:
+    name: Linux Export
+    runs-on: ubuntu-latest
+    container:
+      image: barichello/godot-ci:4.5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Setup Export Templates
+        run: |
+          mkdir -v -p ~/.local/share/godot/export_templates/
+          mkdir -v -p ~/.config/
+          mv /root/.config/godot ~/.config/godot
+          mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
+
+      - name: Build Linux Export
+        run: |
+          mkdir -v -p build/linux
+          EXPORT_DIR="$(readlink -f build)"
+          cd $PROJECT_PATH
+          godot --headless --verbose --export-release "Linux" "$EXPORT_DIR/linux/$EXPORT_NAME.x86_64"
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-build
+          path: build/linux
+          retention-days: 1
+
+  deploy-itchio:
+    name: Deploy to itch.io
+    needs: [export-web, export-windows, export-linux]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Web Build
+        uses: actions/download-artifact@v4
+        with:
+          name: web-build
+          path: build/web
+
+      - name: Download Windows Build
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-build
+          path: build/windows
+
+      - name: Download Linux Build
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-build
+          path: build/linux
+
+      - name: Setup Butler
+        uses: jdno/setup-butler@v1
+
+      - name: Deploy to itch.io
+        env:
+          BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
+        run: |
+          butler push build/web ${{ env.ITCH_USER }}/${{ env.ITCH_GAME }}:html5 --userversion ${{ github.ref_name }}
+          butler push build/windows ${{ env.ITCH_USER }}/${{ env.ITCH_GAME }}:windows --userversion ${{ github.ref_name }}
+          butler push build/linux ${{ env.ITCH_USER }}/${{ env.ITCH_GAME }}:linux --userversion ${{ github.ref_name }}

--- a/src/export_presets.cfg
+++ b/src/export_presets.cfg
@@ -15,6 +15,7 @@ script_encryption_key=""
 
 custom_template/debug=""
 custom_template/release=""
+rendering/renderer/rendering_method.web="gl_compatibility"
 html/canvas_resize_policy=2
 html/custom_html_shell=""
 html/experimental_virtual_keyboard=false
@@ -32,3 +33,96 @@ progressive_web_app/orientation=0
 variant/export_type=0
 vram_texture_compression/for_desktop=true
 vram_texture_compression/for_mobile=false
+
+[preset.1]
+
+custom_features=""
+exclude_filter=""
+export_filter="all_resources"
+export_path="builds/windows/ShooterCarnival.exe"
+include_filter=""
+name="Windows Desktop"
+platform="Windows Desktop"
+runnable=true
+script_export_mode=1
+script_encryption_key=""
+
+[preset.1.options]
+
+binary_format/embed_pck=false
+custom_template/debug=""
+custom_template/release=""
+debug/export_console_wrapper=1
+texture_format/bptc=true
+texture_format/s3tc=true
+binary_format/architecture="x86_64"
+codesign/enable=false
+codesign/timestamp=true
+codesign/timestamp_server_url=""
+codesign/digest_algorithm=1
+codesign/description=""
+codesign/custom_options=PackedStringArray()
+application/modify_resources=true
+application/icon=""
+application/console_wrapper_icon=""
+application/icon_interpolation=4
+application/file_version=""
+application/product_version=""
+application/company_name=""
+application/product_name="ShooterCarnival"
+application/file_description=""
+application/copyright=""
+application/trademarks=""
+application/export_angle=0
+ssh_remote_deploy/enabled=false
+ssh_remote_deploy/host="user@host_ip"
+ssh_remote_deploy/port="22"
+ssh_remote_deploy/extra_args_ssh=""
+ssh_remote_deploy/extra_args_scp=""
+ssh_remote_deploy/run_script="Expand-Archive -LiteralPath '{temp_dir}\\{archive_name}' -DestinationPath '{temp_dir}'
+$action = New-ScheduledTaskAction -Execute '{temp_dir}\\{exe_name}' -Argument '{cmd_args}'
+$trigger = New-ScheduledTaskTrigger -Once -At 00:00
+$settings = New-ScheduledTaskSettingsSet
+$task = New-ScheduledTask -Action $action -Trigger $trigger -Settings $settings
+Register-ScheduledTask godot_remote_debug -InputObject $task -Force:$true
+Start-ScheduledTask -TaskName godot_remote_debug
+while (Get-ScheduledTask -TaskName godot_remote_debug | ? State -eq running) { Start-Sleep -Milliseconds 100 }
+Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue"
+ssh_remote_deploy/cleanup_script="Stop-ScheduledTask -TaskName godot_remote_debug -ErrorAction:SilentlyContinue
+Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue
+Remove-Item -Recurse -Force '{temp_dir}'"
+
+[preset.2]
+
+custom_features=""
+exclude_filter=""
+export_filter="all_resources"
+export_path="builds/linux/ShooterCarnival.x86_64"
+include_filter=""
+name="Linux"
+platform="Linux"
+runnable=true
+script_export_mode=1
+script_encryption_key=""
+
+[preset.2.options]
+
+binary_format/embed_pck=false
+custom_template/debug=""
+custom_template/release=""
+debug/export_console_wrapper=1
+texture_format/bptc=true
+texture_format/s3tc=true
+binary_format/architecture="x86_64"
+ssh_remote_deploy/enabled=false
+ssh_remote_deploy/host="user@host_ip"
+ssh_remote_deploy/port="22"
+ssh_remote_deploy/extra_args_ssh=""
+ssh_remote_deploy/extra_args_scp=""
+ssh_remote_deploy/run_script="#!/usr/bin/env bash
+export DISPLAY=:0
+unzip -o -q \"{temp_dir}/{archive_name}\" -d \"{temp_dir}\"
+\"{temp_dir}/{exe_name}\" {cmd_args}"
+ssh_remote_deploy/cleanup_script="#!/usr/bin/env bash
+kill $(pgrep -x -f \"{temp_dir}/{exe_name} {cmd_args}\")
+rm -rf \"{temp_dir}\""


### PR DESCRIPTION
Apologies for the delay in implementing this!
This PR implements automatic deployment to itch.io using GitHub Actions and Butler, as proposed in #138.
## Changes
**Added:**
- [.github/workflows/deploy-itchio.yml](cci:7://file:///c:/Users/joshu/Documents/Godot_Projects/FORKS/ShooterCarnival/.github/workflows/deploy-itchio.yml:0:0-0:0) - Multi-platform CI/CD workflow
**Modified:**
- [src/export_presets.cfg](cci:7://file:///c:/Users/joshu/Documents/Godot_Projects/FORKS/ShooterCarnival/src/export_presets.cfg:0:0-0:0):
  - Added Windows Desktop export preset (x86_64)
  - Added Linux export preset (x86_64)
  - Added Compatibility renderer override for Web export
## Workflow Behavior
- **Triggers:** Version tags (`v*`) or manual dispatch
- **Builds:** Web (HTML5), Windows, Linux
- **Deploys:** All builds to `houzenkai/shooter-carnival` on itch.io
- **Channels:** `html5`, `windows`, `linux`
## Prerequisites
- ✅ `BUTLER_API_KEY` secret (already configured)
- ✅ itch.io page settings (HTML + SharedArrayBuffer enabled)
## Testing
After merge, test with:
```bash
git tag v0.1.0-test
git push origin v0.1.0-test
```
Or use workflow dispatch from the Actions tab.

Resolves #138