### PR TITLE
#146 Implemented platoon respawning

### DIFF
--- a/src/components/messages/message_payload.gd
+++ b/src/components/messages/message_payload.gd
@@ -31,7 +31,7 @@ class PlayerDeath extends MessagePayload:
 ## Payload for when the player dies (MessageType.PLAYER_DIED).
 	var player_id: int
 	var final_position: Vector2
-	
+
 	func _init(thePlayerId: int, position: Vector2 = Vector2.ZERO) -> void:
 		self.player_id = thePlayerId
 		self.final_position = position

--- a/src/entities/enemies/jumping_enemy/enemy.gd
+++ b/src/entities/enemies/jumping_enemy/enemy.gd
@@ -67,6 +67,9 @@ func randomize_initial_position() -> Vector2:
 	pos.x = clamp(pos.x, half_size.x, view_port_size.x - half_size.x)
 	return pos
 
+func increase_base_speed(percent: float) -> void:
+	base_speed *= (1.0 + percent)
+
 func final_speed() -> int:
 	return base_speed + randi_range(speed_variation_min, speed_variation_max)
 

--- a/src/entities/enemies/jumping_enemy/enemy.gd
+++ b/src/entities/enemies/jumping_enemy/enemy.gd
@@ -103,7 +103,7 @@ func damage(damage_amount:int) -> void:
 	sprite.visible = false
 	explosion_sprite.visible = true
 	explosion_sprite.play("explode")
-	
+
 	await explosion_sprite.animation_finished
 
 	GlobalUtils.CombatBus.publish(

--- a/src/entities/enemies/jumping_enemy/enemy.gd
+++ b/src/entities/enemies/jumping_enemy/enemy.gd
@@ -99,7 +99,6 @@ func damage(damage_amount:int) -> void:
 	if $AudioStreamPlayer != null:
 		$AudioStreamPlayer.play()
 
-
 	# Play explosion animation
 	sprite.visible = false
 	explosion_sprite.visible = true

--- a/src/entities/enemies/jumping_enemy/enemy.gd
+++ b/src/entities/enemies/jumping_enemy/enemy.gd
@@ -38,9 +38,6 @@ func _process(delta: float) -> void:
 		return
 
 	position.y += speed * delta
-	# Check if enemy has moved off the bottom of the screen
-	if position.y > (view_port_size.y + full_size.y + 1):
-		initialize_enemy()
 
 func setup(pos: Vector2) -> void:
 	initial_position = pos

--- a/src/entities/enemies/jumping_enemy/enemy.tscn
+++ b/src/entities/enemies/jumping_enemy/enemy.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=3 uid="uid://bbuh2ow3ysnyy"]
+[gd_scene format=3 uid="uid://bbuh2ow3ysnyy"]
 
 [ext_resource type="Script" uid="uid://dooqgmc5tmkvq" path="res://entities/enemies/jumping_enemy/enemy.gd" id="1_5lf1o"]
 [ext_resource type="Texture2D" uid="uid://dwib7fuoy11wm" path="res://assets/Mini Pixel Pack 3/Enemies/Alan (16 x 16).png" id="2_msovg"]
@@ -145,28 +145,26 @@ animations = [{
 "speed": 10.0
 }]
 
-[node name="Enemy" type="Area2D"]
+[node name="Enemy" type="Area2D" unique_id=1967719583]
 script = ExtResource("1_5lf1o")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=1377470740]
 position = Vector2(0, 0.5)
 shape = SubResource("RectangleShape2D_7p1mj")
 
-[node name="Sprite2D" type="Sprite2D" parent="."]
+[node name="Sprite2D" type="Sprite2D" parent="." unique_id=328392091]
 texture = ExtResource("2_msovg")
 hframes = 6
 frame = 4
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="Sprite2D"]
-libraries = {
-&"": SubResource("AnimationLibrary_5uy6h")
-}
-autoplay = "jump"
+[node name="AnimationPlayer" type="AnimationPlayer" parent="Sprite2D" unique_id=348354531]
+libraries/ = SubResource("AnimationLibrary_5uy6h")
+autoplay = &"jump"
 
-[node name="ExplosionSprite" type="AnimatedSprite2D" parent="."]
+[node name="ExplosionSprite" type="AnimatedSprite2D" parent="." unique_id=705775732]
 visible = false
 sprite_frames = SubResource("SpriteFrames_y5th1")
 animation = &"explode"
 
-[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
+[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="." unique_id=851415491]
 stream = ExtResource("4_kx8w2")

--- a/src/entities/ships/red_ship/red_ship.gd
+++ b/src/entities/ships/red_ship/red_ship.gd
@@ -83,13 +83,13 @@ func _on_health_component_health_changed(change: HealthChange) -> void:
 func _on_health_component_died() -> void:
 	# For now, destroy the player on any hit
 	# print_debug("Player died!")
-	
+
 	# Disable and hide the player
 	collision_shape.set_deferred("disabled", true)
 	set_process(false)
 	set_physics_process(false)
 	hide()
-	
+
 	# Send message "Player Died" to the event bus
 	var death_payload = MessagePayload.PlayerDeath.new(player_id, position)
 	GlobalUtils.CombatBus.publish(GlobalUtils.CombatBus.MessageType.PLAYER_DIED, death_payload)

--- a/src/entities/spawners/enemy_spawner.gd
+++ b/src/entities/spawners/enemy_spawner.gd
@@ -1,19 +1,48 @@
 extends Node2D
 
 @export var enemy_scene: PackedScene = preload("res://entities/enemies/jumping_enemy/enemy.tscn")
-@export var spawn_interval: float = 1
 @export var spawn_interval_decrement: float = 0.05
 
-var timer: Timer = null
+## Maximum number of enemies in a platoon
+@export var max_platoon_size: int = 30
+## Maximum number of enemies in a row to not exceed screen space
+@export var max_enemies_in_row: int = 12
+@export var speed_increase_step: float = 0.1
+
+@onready var spawn_timer: Timer = $SpawnTimer
+
 var minimum_spawn_interval: float = 0.050
+var alive_enemies: int = 0
+var speed_increase_total : float = 0.0
+
 
 func _ready() -> void:
-	timer = Timer.new()
-	timer.wait_time = spawn_interval
-	timer.autostart = true
-	timer.timeout.connect(_on_timer_timeout)
-	add_child(timer)
+	_spawn_enemies_platoon_async()
 	GlobalUtils.CombatBus.subscribe(MessageBus.MessageType.ENEMY_DAMAGED).connect(_on_enemy_died)
+
+var speed_increase_percent : float = 0.1
+
+## Spawns a platoon of enemies over multiple frames to avoid frame drops on game start.
+## This creates a wave of enemies spread across the top of the screen.
+func _spawn_enemies_platoon_async() -> void: #TODO Object Pool
+	var x_position: int = 20
+	var y_position: int = 16
+	speed_increase_total += speed_increase_percent
+	alive_enemies += max_platoon_size
+	
+	for i in max_platoon_size:
+		var enemy_instance: Node2D = enemy_scene.instantiate()
+		enemy_instance.increase_base_speed(speed_increase_total)
+		enemy_instance.setup(Vector2(x_position, y_position))
+		
+		x_position += 18
+		if (i + 1) % max_enemies_in_row == 0: # Prevent spawning enemies out of screen
+			x_position = 20 
+			y_position -= 16
+		
+		add_child(enemy_instance)
+		# Spread spawning across multiple frames to prevent stuttering
+		await get_tree().process_frame
 
 
 # Timer timeout callback that triggers enemy spawning.
@@ -28,15 +57,27 @@ func spawn_enemy() -> void:
 		var screen_size = get_viewport_rect().size
 		# Random position at top of screen
 		var spawn_position := Vector2(randf_range(20, screen_size.x - 20), -20)
+		enemy.increase_base_speed(speed_increase_total)
 		if enemy.has_method("setup"):
 			enemy.setup(spawn_position)
 		else:
 			enemy.position = spawn_position
 
 		add_child(enemy)
+		alive_enemies += 1
+
 
 func _on_enemy_died(_payload: MessagePayload.EnemyDamage) -> void:
-	if spawn_interval >= minimum_spawn_interval:
-		spawn_interval -= spawn_interval_decrement
-		timer.wait_time = spawn_interval
-		# print_debug("New spawn interval: ", timer.wait_time)
+	alive_enemies -= 1
+	if alive_enemies == 0:
+		_spawn_enemies_platoon_async()
+	
+	if spawn_timer.wait_time >= minimum_spawn_interval:
+		spawn_timer.wait_time -= spawn_interval_decrement
+
+
+func _on_despawn_area_area_entered(area: Area2D) -> void:
+	alive_enemies -= 1
+	if alive_enemies == 0:
+		_spawn_enemies_platoon_async()
+	area.queue_free() #TODO reuse with object pool

--- a/src/entities/spawners/enemy_spawner.gd
+++ b/src/entities/spawners/enemy_spawner.gd
@@ -20,7 +20,7 @@ var platoon_spawning : bool = false
 
 func _ready() -> void:
 	_spawn_enemies_platoon_async()
-	GlobalUtils.CombatBus.subscribe(MessageBus.MessageType.ENEMY_DAMAGED).connect(_on_enemy_died)
+	GlobalUtils.CombatBus.subscribe(MessageBus.MessageType.ENEMY_DIED).connect(_on_enemy_died)
 
 var speed_increase_percent : float = 0.1
 
@@ -64,7 +64,7 @@ func spawn_enemy() -> void:
 		var enemy: Node2D = enemy_scene.instantiate()
 		var screen_size = get_viewport_rect().size
 		# Random position at top of screen
-		var spawn_position := Vector2(randf_range(20, screen_size.x - 20), -20)
+		var spawn_position := Vector2(randf_range(20, screen_size.x - 20), -10)
 		enemy.increase_base_speed(speed_increase_total)
 		if enemy.has_method("setup"):
 			enemy.setup(spawn_position)
@@ -75,10 +75,12 @@ func spawn_enemy() -> void:
 		alive_enemies += 1
 
 
-func _on_enemy_died(_payload: MessagePayload.EnemyDamage) -> void:
+func _on_enemy_died(_payload: MessagePayload.EnemyDeath) -> void:
 	alive_enemies -= 1
 	if alive_enemies == 0:
 		_spawn_enemies_platoon_async()
+	
+	print(alive_enemies)
 	
 	if spawn_timer.wait_time >= minimum_spawn_interval:
 		spawn_timer.wait_time -= spawn_interval_decrement
@@ -88,4 +90,7 @@ func _on_despawn_area_area_entered(area: Area2D) -> void:
 	alive_enemies -= 1
 	if alive_enemies == 0:
 		_spawn_enemies_platoon_async()
+	
+	print(alive_enemies)
+	
 	area.queue_free() #TODO reuse with object pool

--- a/src/entities/spawners/enemy_spawner.gd
+++ b/src/entities/spawners/enemy_spawner.gd
@@ -14,6 +14,8 @@ extends Node2D
 var minimum_spawn_interval: float = 0.050
 var alive_enemies: int = 0
 var speed_increase_total : float = 0.0
+var platoon_spawning : bool = false
+
 
 
 func _ready() -> void:
@@ -25,6 +27,10 @@ var speed_increase_percent : float = 0.1
 ## Spawns a platoon of enemies over multiple frames to avoid frame drops on game start.
 ## This creates a wave of enemies spread across the top of the screen.
 func _spawn_enemies_platoon_async() -> void: #TODO Object Pool
+	if platoon_spawning:
+		return
+	platoon_spawning = true
+	
 	var x_position: int = 20
 	var y_position: int = 16
 	speed_increase_total += speed_increase_percent
@@ -43,6 +49,8 @@ func _spawn_enemies_platoon_async() -> void: #TODO Object Pool
 		add_child(enemy_instance)
 		# Spread spawning across multiple frames to prevent stuttering
 		await get_tree().process_frame
+	
+	platoon_spawning = false
 
 
 # Timer timeout callback that triggers enemy spawning.

--- a/src/entities/spawners/enemy_spawner.gd
+++ b/src/entities/spawners/enemy_spawner.gd
@@ -2,27 +2,25 @@ extends Node2D
 
 @export var enemy_scene: PackedScene = preload("res://entities/enemies/jumping_enemy/enemy.tscn")
 @export var spawn_interval_decrement: float = 0.05
-
 ## Maximum number of enemies in a platoon
 @export var max_platoon_size: int = 30
 ## Maximum number of enemies in a row to not exceed screen space
 @export var max_enemies_in_row: int = 12
+## The percentage increase of enemy speed
 @export var speed_increase_step: float = 0.1
 
 @onready var spawn_timer: Timer = $SpawnTimer
 
-var minimum_spawn_interval: float = 0.050
-var alive_enemies: int = 0
+var minimum_spawn_interval : float = 0.050
+var alive_enemies : int = 0
 var speed_increase_total : float = 0.0
 var platoon_spawning : bool = false
-
 
 
 func _ready() -> void:
 	_spawn_enemies_platoon_async()
 	GlobalUtils.CombatBus.subscribe(MessageBus.MessageType.ENEMY_DIED).connect(_on_enemy_died)
 
-var speed_increase_percent : float = 0.1
 
 ## Spawns a platoon of enemies over multiple frames to avoid frame drops on game start.
 ## This creates a wave of enemies spread across the top of the screen.
@@ -30,26 +28,26 @@ func _spawn_enemies_platoon_async() -> void: #TODO Object Pool
 	if platoon_spawning:
 		return
 	platoon_spawning = true
-	
+
 	var x_position: int = 20
 	var y_position: int = 16
-	speed_increase_total += speed_increase_percent
+	speed_increase_total += speed_increase_step
 	alive_enemies += max_platoon_size
-	
+
 	for i in max_platoon_size:
 		var enemy_instance: Node2D = enemy_scene.instantiate()
 		enemy_instance.increase_base_speed(speed_increase_total)
 		enemy_instance.setup(Vector2(x_position, y_position))
-		
+
 		x_position += 18
 		if (i + 1) % max_enemies_in_row == 0: # Prevent spawning enemies out of screen
-			x_position = 20 
+			x_position = 20
 			y_position -= 16
-		
+
 		add_child(enemy_instance)
 		# Spread spawning across multiple frames to prevent stuttering
 		await get_tree().process_frame
-	
+
 	platoon_spawning = false
 
 
@@ -79,9 +77,9 @@ func _on_enemy_died(_payload: MessagePayload.EnemyDeath) -> void:
 	alive_enemies -= 1
 	if alive_enemies == 0:
 		_spawn_enemies_platoon_async()
-	
+
 	print(alive_enemies)
-	
+
 	if spawn_timer.wait_time >= minimum_spawn_interval:
 		spawn_timer.wait_time -= spawn_interval_decrement
 
@@ -90,7 +88,7 @@ func _on_despawn_area_area_entered(area: Area2D) -> void:
 	alive_enemies -= 1
 	if alive_enemies == 0:
 		_spawn_enemies_platoon_async()
-	
+
 	print(alive_enemies)
-	
+
 	area.queue_free() #TODO reuse with object pool

--- a/src/entities/spawners/enemy_spawner.tscn
+++ b/src/entities/spawners/enemy_spawner.tscn
@@ -1,6 +1,22 @@
-[gd_scene load_steps=2 format=3 uid="uid://c7wvb7hflkq4l"]
+[gd_scene format=3 uid="uid://c7wvb7hflkq4l"]
 
 [ext_resource type="Script" uid="uid://be7nmyhmtu1ea" path="res://entities/spawners/enemy_spawner.gd" id="1_8x1j0"]
 
-[node name="EnemySpawner" type="Node2D"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_8x1j0"]
+size = Vector2(283, 20)
+
+[node name="EnemySpawner" type="Node2D" unique_id=1779925057]
 script = ExtResource("1_8x1j0")
+
+[node name="DespawnArea" type="Area2D" parent="." unique_id=1412857971]
+position = Vector2(0, 339)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="DespawnArea" unique_id=265061178]
+position = Vector2(116.5, 0)
+shape = SubResource("RectangleShape2D_8x1j0")
+
+[node name="SpawnTimer" type="Timer" parent="." unique_id=1825640010]
+autostart = true
+
+[connection signal="area_entered" from="DespawnArea" to="." method="_on_despawn_area_area_entered"]
+[connection signal="timeout" from="SpawnTimer" to="." method="_on_timer_timeout"]

--- a/src/scenes/stages/stage_01.gd
+++ b/src/scenes/stages/stage_01.gd
@@ -11,9 +11,6 @@ extends Node2D
 ## Path to the game over scene.
 @export_file("*.tscn") var game_over_scene_path: String = "res://scenes/ui/game_over.tscn"
 
-## Enemy scene to spawn
-var enemy_scene: PackedScene = preload("res://entities/enemies/jumping_enemy/enemy.tscn")
-
 ## Reference to the player (direct child of this stage)
 @onready var player: Area2D = $Player
 @onready var hud: CanvasLayer = $HUD
@@ -23,22 +20,6 @@ func _ready() -> void:
 	GameStats.reset()
 	GlobalUtils.CombatBus.subscribe(GlobalUtils.CombatBus.MessageType.ENEMY_DIED).connect(_on_enemy_died)
 	GlobalUtils.CombatBus.subscribe(GlobalUtils.CombatBus.MessageType.PLAYER_DIED).connect(_on_player_died)
-	_spawn_initial_enemies_async()
-
-
-## Spawns initial enemies over multiple frames to avoid frame drops on game start.
-## This creates a wave of enemies spread across the top of the screen.
-func _spawn_initial_enemies_async() -> void:
-	var x_position: int = 0
-	for _i in max_initial_enemies:
-		var enemy_instance: Node2D = enemy_scene.instantiate()
-		enemy_instance.setup(Vector2(x_position, 16))
-		x_position += 18
-		add_child(enemy_instance)
-		# Connect the enemy's destroyed signal to our score handler
-		#enemy_instance.enemy_destroyed.connect(_on_enemy_destroyed)
-		# Spread spawning across multiple frames to prevent stuttering
-		await get_tree().process_frame
 
 
 ## Called when the player dies. Shows the Game Over scene.


### PR DESCRIPTION
Introduce async platoon spawning and refactor enemy spawner logic. Added increase_base_speed() to enemy to support global speed scaling. Reworked enemy_spawner to use a SpawnTimer node, track alive_enemies, support configurable max_platoon_size and max_enemies_in_row preventing out of screen drawing, and incrementally increase enemy speed per wave. A DespawnArea handles cleanup; Removed the old timer creation and initial spawn logic from stage scene and cleaned up scene files.